### PR TITLE
🔨 [tuning] Optimize utils using built-in func and list comprehension

### DIFF
--- a/avro/utils/count.py
+++ b/avro/utils/count.py
@@ -1,8 +1,9 @@
+from avro import config
+
 # SPDX-License-Identifier: MIT
 
 
 # Import local modules.
-from avro import config
 
 
 # Functions.
@@ -11,13 +12,7 @@ def count_vowels(text: str) -> int:
     Count number of occurrences of vowels in a given string.
     """
 
-    count = 0
-
-    for i in text:
-        if i.lower() in config.AVRO_VOWELS:
-            count += 1
-
-    return count
+    return sum(1 for i in text if i.lower() in config.AVRO_VOWELS)
 
 
 def count_consonants(text: str) -> int:
@@ -25,10 +20,4 @@ def count_consonants(text: str) -> int:
     Count number of occurrences of consonants in a given string.
     """
 
-    count = 0
-
-    for i in text:
-        if i.lower() in config.AVRO_CONSONANTS:
-            count += 1
-
-    return count
+    return sum(1 for i in text if i.lower() in config.AVRO_CONSONANTS)


### PR DESCRIPTION
This PR changes:

- Two functions, `count_vowels()` and `count_consonants()` inside the utils package (avro/utils/count.py) so that they use the built-in `sum()` function, along with list comprehension to quickly scroll through the provided inventory variables on runtime.

Attempts to fix: https://github.com/hitblast/avro.py/issues/31