### PR TITLE
Use contextlib.suppress instead of empty pass

### DIFF
--- a/avro/main.py
+++ b/avro/main.py
@@ -2,6 +2,7 @@
 
 
 # Import first-party Python libraries.
+import contextlib
 import re
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from functools import lru_cache
@@ -327,14 +328,11 @@ def _reverse_with_rules(cursor: int, fixed_text: str, text_reversed: str) -> str
     ):
         added_suffix = "o"
 
-    try:
+    with contextlib.suppress(IndexError):
         if (fixed_text[cursor + 1] in config.AVRO_KAR) or (
             fixed_text[cursor + 2] in config.AVRO_KAR and not cursor == 0
         ):
             added_suffix = ""
-
-    except IndexError:
-        pass
 
     return text_reversed if not text_reversed else text_reversed + added_suffix
 


### PR DESCRIPTION
Ei pattern ta boro boro codebase e use hoy and this is most likely the default way to handle exceptions
